### PR TITLE
正規表現系がgcc-4.9以下だとこける

### DIFF
--- a/cappuccino.h
+++ b/cappuccino.h
@@ -13,7 +13,7 @@
 #include <functional>
 #include <map>
 #include <list>
-#include <regex>
+//#include <regex>
 #include <vector>
 #include <fstream>
 #include <future>
@@ -352,55 +352,23 @@ namespace Cappuccino{
 
 		        string response(buf.begin(), buf.end());
 
-
+/*
 				std::smatch m;
 				std::regex rejpg( R"(^\xFF\xD8)");
 				std::regex repng( R"(^\x89PNG)");
 				std::regex regif( R"(^GIF8[79]a)");
+*/
 
-		    	Logger::i("regex 2");
-#ifdef __APPLE__
-				if(std::regex_search( response, m, rejpg )){
+				if( response[0] == '\xFF' && response[1] == '\xD8'){
 					return make_pair(response, "image/jpg");
-			    }else if(std::regex_search( response, m, repng )){
+				}else if( response[0] == '\x89' && response[1] == 'P' && response[2] == 'N' && response[3] == 'G'){
 					return make_pair(response, "image/png");
-			    }else if(std::regex_search( response, m, regif )){
+				}else if( response[0] == 'G' && response[1] == 'I' && response[2] == 'F' && response[3] == '8' && (response[4] == '7' || response[4] == '9') && response[2] == 'a'){
 					return make_pair(response, "image/gif");
 				}else{
 					replace_all(&response);
 					return std::make_pair(response, "text/html");
 				}
-#else
-	#ifdef __GNUC__
-
-		if(__GNUC__ >= 4 && __GNUC_MINOR__ >= 9){
-				if(std::regex_search( response, m, rejpg )){
-					return make_pair(response, "image/jpg");
-			    }else if(std::regex_search( response, m, repng )){
-					return make_pair(response, "image/png");
-			    }else if(std::regex_search( response, m, regif )){
-					return make_pair(response, "image/gif");
-				}else{
-					replace_all(&response);
-					return std::make_pair(response, "text/html");
-				}
-		}else{
-	    	Logger::i("nuuse regex 2");			
-			if( response[0] == '\xFF' && response[1] == '\xD8'){
-				return make_pair(response, "image/jpg");
-			}else if( response[0] == '\x89' && response[1] == 'P' && response[2] == 'N' && response[3] == 'G'){
-				return make_pair(response, "image/png");
-			}else if( response[0] == 'G' && response[1] == 'I' && response[2] == 'F' && response[3] == '8' && (response[4] == '7' || response[4] == '9') && response[2] == 'a'){
-				return make_pair(response, "image/gif");
-			}else{
-				replace_all(&response);
-				return std::make_pair(response, "text/html");
-			}
-		}
-
-	#endif
-#endif
-	    	Logger::i("regex 2 end");
 
 		    } catch ( std::exception & exception ){
 				Logger::e(exception.what());
@@ -561,8 +529,8 @@ namespace Cappuccino{
 			return res;
 		}
 	}
-	std::regex re( R"(<\w+>)");
-    std::smatch m;    
+//	std::regex re( R"(<\w+>)");
+//    std::smatch m;    
 	// Todo more short	
 	static Response create_response(char* method, char* url, char* protocol,char* req){
 		Request* request = new Request( string(method), string(url), string(protocol), string(req));
@@ -573,29 +541,8 @@ namespace Cappuccino{
 		for(auto url = routes_.begin(), end = routes_.end(); url != end; ++url){
 			correct = true;
 		    if(url->first.find("<", 0) != string::npos){
-		    	Logger::i("regex 1");
-#ifdef __APPLE__
-			    auto iter = url->first.cbegin();
-			    while ( std::regex_search( iter, url->first.cend(), m, re )){
-			        reg.push_back(m.str());
-			        iter = m[0].second;
-			    }
-#else
-	#ifdef __GNUC__
 
-				if(__GNUC__ >= 4 && __GNUC_MINOR__ >= 9){
-				    auto iter = url->first.cbegin();
-				    while ( std::regex_search( iter, url->first.cend(), m, re )){
-				        reg.push_back(m.str());
-				        iter = m[0].second;
-				    }
-				}else{
-		    	Logger::i("unuse regex");
-					reg = Regex::findParent(url->first);
-				}
-	#endif
-#endif
-		    	Logger::i("regex 1 end");
+				reg = Regex::findParent(url->first);
 
 			    if(reg.size() != 0){
 			    	auto val = split(url->first, "/");

--- a/cappuccino.h
+++ b/cappuccino.h
@@ -44,6 +44,7 @@ namespace Logger{
    	} 
 }
 
+
 namespace Cappuccino{
 	
 	using string = std::string;
@@ -351,11 +352,14 @@ namespace Cappuccino{
 
 		        string response(buf.begin(), buf.end());
 
+
 				std::smatch m;
 				std::regex rejpg( R"(^\xFF\xD8)");
 				std::regex repng( R"(^\x89PNG)");
 				std::regex regif( R"(^GIF8[79]a)");
 
+		    	Logger::i("regex 2");
+#ifdef __APPLE__
 				if(std::regex_search( response, m, rejpg )){
 					return make_pair(response, "image/jpg");
 			    }else if(std::regex_search( response, m, repng )){
@@ -366,19 +370,38 @@ namespace Cappuccino{
 					replace_all(&response);
 					return std::make_pair(response, "text/html");
 				}
+#else
+	#ifdef __GNUC__
 
-		        /*
-				if( response[0] == '\xFF' && response[1] == '\xD8'){
+		if(__GNUC__ >= 4 && __GNUC_MINOR__ >= 9){
+				if(std::regex_search( response, m, rejpg )){
 					return make_pair(response, "image/jpg");
-				}else if( response[0] == '\x89' && response[1] == 'P' && response[2] == 'N' && response[3] == 'G'){
+			    }else if(std::regex_search( response, m, repng )){
 					return make_pair(response, "image/png");
-				}else if( response[0] == 'G' && response[1] == 'I' && response[2] == 'F' && response[3] == '8' && (response[4] == '7' || response[4] == '9') && response[2] == 'a'){
+			    }else if(std::regex_search( response, m, regif )){
 					return make_pair(response, "image/gif");
 				}else{
 					replace_all(&response);
 					return std::make_pair(response, "text/html");
 				}
-				*/
+		}else{
+	    	Logger::i("nuuse regex 2");			
+			if( response[0] == '\xFF' && response[1] == '\xD8'){
+				return make_pair(response, "image/jpg");
+			}else if( response[0] == '\x89' && response[1] == 'P' && response[2] == 'N' && response[3] == 'G'){
+				return make_pair(response, "image/png");
+			}else if( response[0] == 'G' && response[1] == 'I' && response[2] == 'F' && response[3] == '8' && (response[4] == '7' || response[4] == '9') && response[2] == 'a'){
+				return make_pair(response, "image/gif");
+			}else{
+				replace_all(&response);
+				return std::make_pair(response, "text/html");
+			}
+		}
+
+	#endif
+#endif
+	    	Logger::i("regex 2 end");
+
 		    } catch ( std::exception & exception ){
 				Logger::e(exception.what());
 				return std::make_pair("", "text/html");	
@@ -544,18 +567,35 @@ namespace Cappuccino{
 	static Response create_response(char* method, char* url, char* protocol,char* req){
 		Request* request = new Request( string(method), string(url), string(protocol), string(req));
 		
-	    std::list<string> reg;
+	    std::vector<string> reg;
 
 	    bool correct = true;
 		for(auto url = routes_.begin(), end = routes_.end(); url != end; ++url){
 			correct = true;
 		    if(url->first.find("<", 0) != string::npos){
-		    	// ToDo split sub function.
+		    	Logger::i("regex 1");
+#ifdef __APPLE__
 			    auto iter = url->first.cbegin();
 			    while ( std::regex_search( iter, url->first.cend(), m, re )){
 			        reg.push_back(m.str());
 			        iter = m[0].second;
 			    }
+#else
+	#ifdef __GNUC__
+
+				if(__GNUC__ >= 4 && __GNUC_MINOR__ >= 9){
+				    auto iter = url->first.cbegin();
+				    while ( std::regex_search( iter, url->first.cend(), m, re )){
+				        reg.push_back(m.str());
+				        iter = m[0].second;
+				    }
+				}else{
+		    	Logger::i("unuse regex");
+					reg = Regex::findParent(url->first);
+				}
+	#endif
+#endif
+		    	Logger::i("regex 1 end");
 
 			    if(reg.size() != 0){
 			    	auto val = split(url->first, "/");

--- a/cappuccino.h
+++ b/cappuccino.h
@@ -13,6 +13,7 @@
 #include <functional>
 #include <map>
 #include <list>
+#include <algorithm>
 //#include <regex>
 #include <vector>
 #include <fstream>

--- a/sample.cpp
+++ b/sample.cpp
@@ -64,8 +64,9 @@ int main(int argc, char *argv[]) {
 		return response;
 	});
 
-	Cappuccino::run();
-/*
+
+#ifdef TEST
+	
 	Cappuccino::add_spec("/ exist",[&](Cappuccino::Application* app) -> bool{
 		std::string res = app->access("/", new Cappuccino::FakeRequest( "GET", "/"));
 		if(res.find("Cappuccino", 0) != std::string::npos)
@@ -74,12 +75,18 @@ int main(int argc, char *argv[]) {
 	});
 	Cappuccino::add_spec("/hoge not exist(will be failed)",[&](Cappuccino::Application* app) -> bool{
 		std::string res = app->access("/hoge", new Cappuccino::FakeRequest( "GET", "/hoge"));
-		if(res.find("Cappuccino", 0) != std::string::npos)
+		if(res.find("Page not found", 0) != std::string::npos)
 			return true;
 		return false;
 	});
 
 	Cappuccino::testRun();
-//*/
+
+#else
+
+	Cappuccino::run();
+
+#endif
+
 	return 0;
 }


### PR DESCRIPTION
対応としてマクロ

``` C
#if defined(__APPLE__) || defined(__GNUC__) && __GNUC__ * 10  + __GNUC_MINOR__ >= 49    
     // 正規表現使う
#else
     // 正規表現使わない
#endif
```
